### PR TITLE
mark `expand` and `isCollapsed` as optional bindings

### DIFF
--- a/src/app/components/tableGroup/tableGroup.directive.js
+++ b/src/app/components/tableGroup/tableGroup.directive.js
@@ -17,9 +17,9 @@
         data: '=',
         totals: '=',
         color: '=',
-        expand: '=',
+        expand: '=?',
         type: '@',
-        isCollapsed: '='
+        isCollapsed: '=?'
       },
       bindToController: true
     };


### PR DESCRIPTION
These attributes are not always used, so they really should be marked as optional.
Otherwise, this error gets triggered:
https://code.angularjs.org/1.4.9/docs/error/$compile/nonassign
