### PR TITLE
pass errorCallback to angular-cas-auth-api

### DIFF
--- a/src/app/index.config.js
+++ b/src/app/index.config.js
@@ -16,6 +16,7 @@
     casAuthApiProvider
         .setRequireAccessToken( true )
         .setCacheAccessToken( true )
+        .setErrorCallback( settings.errorCallback )
         .setAuthenticationApiBaseUrl( settings.api.casAuthApi )
         .setTicketUrl(settings.api.refresh);
   }


### PR DESCRIPTION
Without this, my errorCallback wasn't called.
